### PR TITLE
Fix/tags and list duplicates

### DIFF
--- a/src/Controller/TagController.php
+++ b/src/Controller/TagController.php
@@ -168,15 +168,17 @@ final class TagController extends AbstractController
     public function editTag(Request $request, Uuid $id, TagRepositoryInterface $tagRepository, ValidatorServiceInterface $validatorService): JsonResponse|RedirectResponse
     {
         $user = $this->getUser();
-        $data = json_decode($request->getContent());
+        $data = json_decode($request->getContent(), true);
+
+        $name = $data['name'] ?? null;
+        $colour = $data['colour'] ?? null;
 
         $tag = $tagRepository->find($id);
-
         if ($tag === null) {
             return new JsonResponse(['error' => 'Tag not found'], Response::HTTP_NOT_FOUND);
         }
 
-        $tagCheck = $tagRepository->findOneBy(['name' => $tag->getName(), 'creator' => $user]);
+        $tagCheck = $tagRepository->findOneBy(['name' => $name, 'creator' => $user]);
         if ($tagCheck !== null) {
             return new JsonResponse(['error' => 'A tag with this name already exists'], Response::HTTP_CONFLICT);
         }
@@ -185,11 +187,8 @@ final class TagController extends AbstractController
             return new JsonResponse(['error' => 'Forbidden to access this resource'], Response::HTTP_FORBIDDEN);
         }
 
-        $name = $data['name'] ?? null;
-        $colour = $data['colour'] ?? null;
-
         if (!empty($name)) {
-            $tag->setTitle($name);
+            $tag->setName($name);
         }
         if (!empty($colour)) {
             $tag->setColour($colour);

--- a/src/Controller/TagController.php
+++ b/src/Controller/TagController.php
@@ -95,9 +95,9 @@ final class TagController extends AbstractController
         $name = $data['name'] ?? null;
         $colour = $data['colour'] ?? null;
 
-        $tagExists = $tagRepository->findOneBy(['name' => $name, 'creator' => $user]);
-        if ($tagExists !== null) {
-            return new JsonResponse(['error' => 'Tag already exists'], Response::HTTP_CONFLICT);
+        $tagCheck = $tagRepository->findOneBy(['name' => $name, 'creator' => $user]);
+        if ($tagCheck !== null) {
+            return new JsonResponse(['error' => 'A tag with this name already exists'], Response::HTTP_CONFLICT);
         }
 
         $newTag = new Tag();
@@ -174,6 +174,11 @@ final class TagController extends AbstractController
 
         if ($tag === null) {
             return new JsonResponse(['error' => 'Tag not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $tagCheck = $tagRepository->findOneBy(['name' => $tag->getName(), 'creator' => $user]);
+        if ($tagCheck !== null) {
+            return new JsonResponse(['error' => 'A tag with this name already exists'], Response::HTTP_CONFLICT);
         }
 
         if ($tag->getCreator()->getId() !== $user->getId()) {

--- a/src/Controller/TagController.php
+++ b/src/Controller/TagController.php
@@ -82,7 +82,7 @@ final class TagController extends AbstractController
             ],
             type: 'object',
             example: [
-                'title' => 'My new tag',
+                'name' => 'My new tag',
                 'colour' => '#4287f5',
             ]
         )
@@ -95,11 +95,15 @@ final class TagController extends AbstractController
         $name = $data['name'] ?? null;
         $colour = $data['colour'] ?? null;
 
+        $tagExists = $tagRepository->findOneBy(['name' => $name, 'creator' => $user]);
+        if ($tagExists !== null) {
+            return new JsonResponse(['error' => 'Tag already exists'], Response::HTTP_CONFLICT);
+        }
+
         $newTag = new Tag();
         $newTag->setName($name);
         $newTag->setColour($colour);
         $newTag->setCreator($user);
-
         $validationResponse = $validatorService->validate($newTag, null, ['tag']);
         if ($validationResponse !== null) {
             return $validationResponse;

--- a/src/Controller/TaskController.php
+++ b/src/Controller/TaskController.php
@@ -355,6 +355,11 @@ final class TaskController extends AbstractController
                 $tag->setName($tagData['name']);
                 $tag->setColour($tagData['colour']);
 
+                $tagCheck = $tagRepository->findOneBy(['name' => $tagData['name'], 'creator' => $user]);
+                if ($tagCheck !== null) {
+                    return new JsonResponse(['error' => "A tag with this name already exists: {$tagData['name']}"], Response::HTTP_CONFLICT);
+                }
+
                 $validationResponse = $validatorService->validate($tag, null, ['tag']);
                 if ($validationResponse !== null) {
                     return $validationResponse;

--- a/src/Controller/TaskListController.php
+++ b/src/Controller/TaskListController.php
@@ -96,7 +96,7 @@ final class TaskListController extends AbstractController
 
         $taskListCheck = $taskListRepository->findOneBy(['name' => $name, 'owner' => $user]);
         if ($taskListCheck !== null) {
-            new JsonResponse(['error' => 'A list with this name already exists'], Response::HTTP_CONFLICT);
+            return new JsonResponse(['error' => 'A list with this name already exists'], Response::HTTP_CONFLICT);
         }
 
         $taskList = new TaskList();
@@ -196,7 +196,7 @@ final class TaskListController extends AbstractController
 
         $taskListCheck = $taskListRepository->findOneBy(['name' => $name, 'owner' => $user]);
         if ($taskListCheck !== null) {
-            new JsonResponse(['error' => 'A list with this name already exists'], Response::HTTP_CONFLICT);
+            return new JsonResponse(['error' => 'A list with this name already exists'], Response::HTTP_CONFLICT);
         }
 
         $tasks = new ArrayCollection($taskRepository->findBy(['id' => $taskIds]));

--- a/src/Controller/TaskListController.php
+++ b/src/Controller/TaskListController.php
@@ -94,6 +94,11 @@ final class TaskListController extends AbstractController
         $data = json_decode($request->getContent(), true);
         $name = $data['name'] ?? null;
 
+        $taskListCheck = $taskListRepository->findOneBy(['name' => $name, 'owner' => $user]);
+        if ($taskListCheck !== null) {
+            new JsonResponse(['error' => 'A list with this name already exists'], Response::HTTP_CONFLICT);
+        }
+
         $taskList = new TaskList();
         $taskList->setName($name);
         $taskList->setOwner($user);
@@ -188,6 +193,11 @@ final class TaskListController extends AbstractController
         $data = json_decode($request->getContent(), true);
         $name = $data['name'] ?? null;
         $taskIds = $data['taskIds'] ?? [];
+
+        $taskListCheck = $taskListRepository->findOneBy(['name' => $name, 'owner' => $user]);
+        if ($taskListCheck !== null) {
+            new JsonResponse(['error' => 'A list with this name already exists'], Response::HTTP_CONFLICT);
+        }
 
         $tasks = new ArrayCollection($taskRepository->findBy(['id' => $taskIds]));
 

--- a/tests/Controller/TaskControllerTest.php
+++ b/tests/Controller/TaskControllerTest.php
@@ -37,8 +37,8 @@ final class TaskControllerTest extends WebTestCase
         // Assert
         $this->assertResponseIsSuccessful();
         $this->assertCount(25, $tasks);
-        assert($tasks[0]["title"] === 'Task 1');
-        assert($tasks[0]["description"] === 'Task description 1');
+        $this->assertEquals('Task 1', $tasks[0]["title"]);
+        $this->assertEquals('Task description 1', $tasks[0]["description"]);
     }
 
     public function testGetTask(): void
@@ -53,9 +53,9 @@ final class TaskControllerTest extends WebTestCase
 
         // Assert
         $this->assertResponseIsSuccessful();
-        assert($response["id"] === (string)$task->getId());
-        assert($response["title"] === 'Task 1');
-        assert($response["description"] === 'Task description 1');
+        $this->assertEquals($response["id"] , (string)$task->getId());
+        $this->assertEquals('Task 1', $response["title"]);
+        $this->assertEquals('Task description 1', $response["description"]);
     }
 
     public function testGetMissingTask(): void
@@ -69,7 +69,7 @@ final class TaskControllerTest extends WebTestCase
 
         // Assert
         $this->assertResponseStatusCodeSame(404);
-        assert($response['error'] === 'Task not found');
+        $this->assertEquals('Task not found', $response['error']);
     }
 
     public function testGetTaskNotOwner(): void
@@ -84,7 +84,7 @@ final class TaskControllerTest extends WebTestCase
 
         // Assert
         $this->assertResponseStatusCodeSame(403);
-        assert($response['error'] === 'Forbidden to access this resource');
+        $this->assertEquals('Forbidden to access this resource', $response['error']);
 
     }
 
@@ -136,7 +136,7 @@ final class TaskControllerTest extends WebTestCase
 
         // Assert
         $this->assertResponseStatusCodeSame(404);
-        assert($response['error'] === 'Parent task not found');
+        $this->assertEquals('Parent task not found', $response['error']);
 
     }
 
@@ -152,7 +152,7 @@ final class TaskControllerTest extends WebTestCase
 
         // Assert
         $this->assertResponseStatusCodeSame(403);
-        assert($response['error'] === 'Forbidden to access this resource');
+        $this->assertEquals('Forbidden to access this resource', $response['error']);
     }
 
     public function testCreateTaskWithMissingTitle(): void
@@ -166,14 +166,14 @@ final class TaskControllerTest extends WebTestCase
 
         // Assert
         $this->assertResponseStatusCodeSame(400);
-        assert($response[0]['field'] === 'title');
-        assert($response[0]['message'] === 'A valid task title is required');
+        $this->assertEquals('title', $response[0]['field']);
+        $this->assertEquals('A valid task title is required', $response[0]['message']);
     }
 
     /**
      * @depends testCreateTask
      */
-    public function testUpdateTask(): void
+    public function testEditTask(): void
     {
         // Arrange
         $task = $this->taskRepository->findOneBy(['title' => 'Task 21']);
@@ -195,7 +195,7 @@ final class TaskControllerTest extends WebTestCase
         $this->assertEquals($testData['description'], $updatedTaskRes->getDescription());
     }
 
-    public function testUpdateTaskNotOwner(): void
+    public function testEditTaskNotOwner(): void
     {
         // Arrange
         $task = $this->taskRepository->findOneBy(['title' => 'Task 20']);
@@ -209,10 +209,10 @@ final class TaskControllerTest extends WebTestCase
 
         // Assert
         $this->assertResponseStatusCodeSame(403);
-        assert($response['error'] === 'Forbidden to access this resource');
+        $this->assertEquals('Forbidden to access this resource', $response['error']);
     }
 
-    public function testUpdateMissingTask(): void
+    public function testEditMissingTask(): void
     {
         // Arrange
         $fakeUuid = Uuid::v4()->toRfc4122();
@@ -223,11 +223,11 @@ final class TaskControllerTest extends WebTestCase
 
         // Assert
         $this->assertResponseStatusCodeSame(404);
-        assert($response['error'] === 'Task not found');
+        $this->assertEquals('Task not found', $response['error']);
     }
 
     /**
-     * @depends testUpdateTask
+     * @depends testEditTask
      */
     public function testDeleteTask(): void
     {
@@ -242,7 +242,7 @@ final class TaskControllerTest extends WebTestCase
         // Assert
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(200);
-        assert($response['success'] === 'Task deleted successfully');
+        $this->assertEquals('Task deleted successfully', $response['success']);
     }
 
     public function testDeleteTaskNotOwner(): void
@@ -257,7 +257,7 @@ final class TaskControllerTest extends WebTestCase
 
         // Assert
         $this->assertResponseStatusCodeSame(403);
-        assert($response['error'] === 'Forbidden to access this resource');
+        $this->assertEquals('Forbidden to access this resource', $response['error']);
     }
 
 
@@ -272,7 +272,7 @@ final class TaskControllerTest extends WebTestCase
 
         // Assert
         $this->assertResponseStatusCodeSame(404);
-        assert($response['error'] === 'Task not found');
+        $this->assertEquals('Task not found', $response['error']);
     }
 
     public function testAddTagsToTasks(): void
@@ -321,7 +321,7 @@ final class TaskControllerTest extends WebTestCase
 
         // Assert
         $this->assertResponseStatusCodeSame(400);
-        assert($response['error'] === 'Task ids and tags are required');
+        $this->assertEquals('Task ids and tags are required', $response['error']);
     }
 
     public function testAddTagsToTasksInvalidTaskIds(): void
@@ -342,7 +342,7 @@ final class TaskControllerTest extends WebTestCase
 
         // Assert
         $this->assertResponseStatusCodeSame(404);
-        assert($response['error'] === 'Some task ids not found');
+        $this->assertEquals('Some task ids not found', $response['error']);
     }
 
     public function testAddTagsToTasksForbiddenAccess(): void
@@ -361,7 +361,7 @@ final class TaskControllerTest extends WebTestCase
 
         // Assert
         $this->assertResponseStatusCodeSame(403);
-        assert($response['error'] === 'Forbidden to access this resource');
+        $this->assertEquals('Forbidden to access this resource', $response['error']);
     }
 
     public function testAddTagsToTasksMissingTagNameOrColour(): void
@@ -379,16 +379,16 @@ final class TaskControllerTest extends WebTestCase
 
         // Assert
         $this->assertResponseStatusCodeSame(400);
-        assert($response['error'] === 'Each tag must have both name and colour');
+        $this->assertEquals('Each tag must have both name and colour', $response['error']);
     }
 
     public function testAddTagsToTasksInvalidTagValidation(): void
     {
-        //
+        // Arrange
         $task = $this->taskRepository->findOneBy(['title' => 'Task 1']);
         $testData = [
             'taskIds' => [$task->getId()],
-            'tags' => [['name' => 'Urgent', 'colour' => 'invalidColour']]
+            'tags' => [['name' => 'InvalidTag', 'colour' => 'invalidColour']]
         ];
 
         // Act
@@ -397,8 +397,38 @@ final class TaskControllerTest extends WebTestCase
         // Assert
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertResponseStatusCodeSame(400);
-        assert($response[0]['field'] === 'colour');
-        assert($response[0]['message'] === 'Tag colour should match a hex colour value');
+        $this->assertEquals('colour', $response[0]['field']);
+        $this->assertEquals('Tag colour should match a hex colour value', $response[0]['message']);
+    }
+
+    public function testAddTagsToTasksDoesNotCreateExistingTag(): void
+    {
+        // Arrange
+        $task1 = $this->taskRepository->findOneBy(['title' => 'Task 1']);
+        $task2 = $this->taskRepository->findOneBy(['title' => 'Task 2']);
+        $tasks = [$task1, $task2];
+        $taskIds = array_map(fn($task) => $task->getId(), $tasks);
+
+        $tagsData = [
+            [
+                'name' => 'Urgent',
+                'colour' => '#FF0000'
+            ]
+        ];
+
+        $testData = [
+            'taskIds' => $taskIds,
+            'tags' => $tagsData
+        ];
+
+        // Act
+        $this->client->request('POST', '/api/task/assign-tags', content: json_encode($testData));
+        $responseContent = json_decode($this->client->getResponse()->getContent(), true);
+
+        // Assert
+        $this->assertResponseStatusCodeSame(409);
+        $this->assertArrayHasKey('error', $responseContent);
+        $this->assertEquals("A tag with this name already exists: {$tagsData[0]['name']}", $responseContent['error']);
     }
 
     public function testRemoveTagsFromTasks(): void

--- a/tests/Controller/TaskListControllerTest.php
+++ b/tests/Controller/TaskListControllerTest.php
@@ -127,6 +127,23 @@ final class TaskListControllerTest extends WebTestCase
         $this->assertEquals('Task list name is required', $response[0]['message']);
     }
 
+    public function testCreateTaskListAlreadyExists()
+    {
+        // Arrange
+        $testData = [
+            'name' => 'List 2',
+        ];
+
+        // Act
+        $this->client->request('POST', '/api/task-list', content: json_encode($testData));
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        // Assert
+        $this->assertEquals(409, $this->client->getResponse()->getStatusCode());
+        $this->assertArrayHasKey('error', $response);
+        $this->assertEquals('A list with this name already exists', $response['error']);
+    }
+
     /**
      * @depends testEditListSuccessfully
      */
@@ -271,6 +288,24 @@ final class TaskListControllerTest extends WebTestCase
         $this->assertIsArray($response);
         $this->assertArrayHasKey('error', $response);
         $this->assertEquals('Forbidden to access this resource', $response['error']);
+    }
+
+    public function testEditTaskListWithNameAlreadyExists()
+    {
+        // Arrange
+        $taskListId = $this->taskListRepository->findOneBy(['name' => 'List 1'])->getId();
+        $testData = [
+            'name' => 'List 2',
+        ];
+
+        // Act
+        $this->client->request('PUT', "/api/task-list/$taskListId", content: json_encode($testData));
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        // Assert
+        $this->assertEquals(409, $this->client->getResponse()->getStatusCode());
+        $this->assertArrayHasKey('error', $response);
+        $this->assertEquals('A list with this name already exists', $response['error']);
     }
 
     // TODO: Functionally useless for now as the name is never passed due to a null check, so it never hits the validator, which for now is the only invalid state.


### PR DESCRIPTION
# Summary
This pull requests introduces an oversight in the business logic of tags and lists. Here the code now checks if a user already has an existing tag or list with the same name of a tag or list being created/edited.

## Additional changes
- Refactor of test code to make the methods used more in line for assertions, also removes redundancies.
- Implements missing tests for editing tags that were forgotten.

## To-do checklist
- [x] Implement new tests for new tag/list logic.